### PR TITLE
Add issue analysis report and fetch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ temp/
 *.tmp
 
 tasks/
+issues_data.json

--- a/fetch_issues.py
+++ b/fetch_issues.py
@@ -1,0 +1,89 @@
+import urllib.request
+import json
+import os
+import sys
+
+def get_json(url, token=None):
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'Python-urllib/3.x')
+        if token:
+            req.add_header('Authorization', f'token {token}')
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"Error fetching {url}: {e.code} {e.reason}")
+        if e.code == 403:
+            print("Rate limit exceeded or forbidden. Check your GITHUB_TOKEN.")
+        return None
+    except Exception as e:
+        print(f"Error fetching {url}: {e}")
+        return None
+
+def main():
+    repo_owner = os.getenv('REPO_OWNER', 'doggy8088')
+    repo_name = os.getenv('REPO_NAME', 'Apptopia')
+    token = os.getenv('GITHUB_TOKEN')
+
+    if len(sys.argv) > 1:
+        repo_owner = sys.argv[1]
+    if len(sys.argv) > 2:
+        repo_name = sys.argv[2]
+
+    print(f"Fetching issues for {repo_owner}/{repo_name}...")
+
+    api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+    issues_url = f"{api_url}/issues?state=open&per_page=100"
+
+    issues = get_json(issues_url, token)
+
+    if not issues:
+        print("No issues found or error fetching issues.")
+        return
+
+    issues_data = []
+
+    for issue in issues:
+        # Skip pull requests
+        if 'pull_request' in issue:
+            continue
+
+        number = issue['number']
+        title = issue['title']
+        body = issue['body']
+        user = issue['user']['login']
+
+        # Fetch comments
+        comments_url = issue['comments_url']
+        comments = get_json(comments_url, token)
+
+        comment_list = []
+        last_comment_user = None
+
+        if comments:
+            for comment in comments:
+                comment_list.append({
+                    'user': comment['user']['login'],
+                    'body': comment['body'],
+                    'created_at': comment['created_at']
+                })
+            last_comment_user = comments[-1]['user']['login']
+
+        issues_data.append({
+            'number': number,
+            'title': title,
+            'body': body,
+            'user': user,
+            'last_comment_user': last_comment_user,
+            'comments': comment_list
+        })
+
+    # Output to stdout or file
+    output_file = 'issues_data.json'
+    with open(output_file, 'w') as f:
+        json.dump(issues_data, f, indent=2)
+
+    print(f"Fetched {len(issues_data)} issues. Data saved to {output_file}")
+
+if __name__ == "__main__":
+    main()

--- a/issue_analysis.md
+++ b/issue_analysis.md
@@ -1,0 +1,29 @@
+# GitHub Issue Analysis
+
+## Issue #11: [工具] 美食地圖
+
+**Status:** Need Clarification
+**Last Action By:** github-actions[bot] (2026-02-21)
+**User:** funew4670
+
+### Analysis
+The requirements for the "Food Map" tool are currently insufficient for development planning. The following key information is missing:
+1.  **Data Source & Authorization:** Whether to use Google Places/Maps API or another source. If Google API, is an API Key provided? What are the quota/budget limits? Is scraping (without official API) acceptable (usually discouraged)?
+2.  **Search Scope:** Is the initial version limited to a single city or global? Does it support user input for location/radius/keywords?
+3.  **Map Interaction:** What details should be shown on clicking a restaurant? Sorting options? Pagination vs. load all?
+4.  **Acceptance Criteria:** Specific examples of search queries and expected results are needed.
+
+### Proposed Comment (Traditional Chinese)
+您好，我們目前仍在等待您針對上述問題的回覆（資料來源、搜尋範圍、地圖與清單互動細節、驗收樣本等）。由於需求尚不明確，目前無法制定開發計畫。若您能提供更多資訊，我們將很樂意協助您評估與規劃。謝謝！
+
+---
+
+## Issue #36: [工具] LinguistFlow
+
+**Status:** Skipped
+**Last Action By:** doggy8088 (2026-02-24)
+**User:** SZZhang0619
+
+### Analysis
+The last comment on this issue was made by `doggy8088`. As per instructions, this issue is skipped.
+Current status seems to be in PR review (PR #38).


### PR DESCRIPTION
This change adds a script to fetch open issues from the GitHub repository and an analysis report of the current open issues. The script `fetch_issues.py` now supports authentication via `GITHUB_TOKEN`. The report `issue_analysis.md` contains the analysis of Issue #11 and #36, including drafted comments for clarification requests.

---
*PR created automatically by Jules for task [18127013979237226803](https://jules.google.com/task/18127013979237226803) started by @doggy8088*