### PR TITLE
Add automated issue triage script

### DIFF
--- a/scripts/test_triage_check.py
+++ b/scripts/test_triage_check.py
@@ -1,0 +1,112 @@
+import unittest
+import sys
+import os
+import json
+import urllib.request
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+# Ensure the parent directory is in the path to import triage_check
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+import triage_check
+
+class TestTriageCheck(unittest.TestCase):
+
+    def setUp(self):
+        # Reset any global state if necessary (none in this script)
+        pass
+
+    @patch("triage_check.make_request")
+    def test_get_open_issues_success(self, mock_make_request):
+        # Mock API response for issues
+        # The script does `if "pull_request" not in i`
+        # Issues do not have 'pull_request' key
+        # PRs have 'pull_request' key
+        mock_make_request.return_value = [
+            {"number": 1, "title": "Issue 1", "body": "Body 1", "user": {"login": "user1"}}, # Issue (no pull_request key)
+            {"number": 2, "title": "PR 1", "body": "Body 2", "user": {"login": "user2"}, "pull_request": {}}, # PR
+            {"number": 3, "title": "Issue 2", "body": "Body 3", "user": {"login": "user3"}} # Issue
+        ]
+
+        # Call the function under test
+        issues = triage_check.get_open_issues()
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0]["number"], 1)
+        self.assertEqual(issues[1]["number"], 3)
+
+    def test_analyze_issue_skip_owner_comment(self):
+        # We need to mock make_request inside analyze_issue
+        with patch("triage_check.make_request") as mock_make_request:
+            # Mock issue
+            issue = {"number": 1, "title": "Test Issue", "body": "Body", "user": {"login": "user1"}}
+
+            # Mock comments: Last one is by owner
+            mock_make_request.return_value = [
+                {"user": {"login": "user1"}, "body": "Comment 1"},
+                {"user": {"login": triage_check.MY_USERNAME}, "body": "Owner comment"}
+            ]
+
+            # Capture log output
+            with patch("builtins.print") as mock_print:
+                triage_check.analyze_issue(issue, dry_run=True)
+                expected_msg = f"[Triage]   -> Skipping: Last comment is by {triage_check.MY_USERNAME}."
+                mock_print.assert_any_call(expected_msg)
+
+    def test_analyze_issue_skip_bot_comment(self):
+        with patch("triage_check.make_request") as mock_make_request:
+            # Mock issue
+            issue = {"number": 1, "title": "Test Issue", "body": "Body", "user": {"login": "user1"}}
+
+            # Mock comments: Last one is by bot
+            mock_make_request.return_value = [
+                {"user": {"login": "user1"}, "body": "Comment 1"},
+                {"user": {"login": "github-actions[bot]"}, "body": "Bot comment"}
+            ]
+
+            # Capture log output
+            with patch("builtins.print") as mock_print:
+                triage_check.analyze_issue(issue, dry_run=True)
+                expected_msg = f"[Triage]   -> Skipping: Last comment is by github-actions[bot]."
+                mock_print.assert_any_call(expected_msg)
+
+    def test_analyze_issue_needs_info(self):
+        with patch("triage_check.make_request") as mock_make_request:
+            # Mock issue with missing sections
+            issue = {"number": 1, "title": "Test Issue", "body": "Some body content but missing headers", "user": {"login": "user1"}}
+
+            # No comments
+            mock_make_request.return_value = []
+
+            # Capture log output
+            with patch("builtins.print") as mock_print:
+                triage_check.analyze_issue(issue, dry_run=True)
+
+                missing_str = "基本資訊, 需求定義, 驗收標準"
+                expected_msg = f"[Triage]   -> Requirements unclear. Missing: {missing_str}"
+                mock_print.assert_any_call(expected_msg)
+
+    def test_analyze_issue_ready_for_plan(self):
+        with patch("triage_check.make_request") as mock_make_request:
+            # Mock issue with all sections
+            body = """
+            ### A. 基本資訊
+            ...
+            ### B. 需求定義
+            ...
+            ### C. 驗收標準
+            ...
+            """
+            issue = {"number": 1, "title": "Test Issue", "body": body, "user": {"login": "user1"}}
+
+            # No comments
+            mock_make_request.return_value = []
+
+            # Capture log output
+            with patch("builtins.print") as mock_print:
+                triage_check.analyze_issue(issue, dry_run=True)
+                expected_msg = "[Triage]   -> Requirements look clear. Preparing plan..."
+                mock_print.assert_any_call(expected_msg)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/triage_check.py
+++ b/scripts/triage_check.py
@@ -1,0 +1,178 @@
+import os
+import sys
+import json
+import urllib.request
+import urllib.parse
+import urllib.error
+import time
+import argparse
+
+# --- Configuration ---
+REPO_OWNER = "doggy8088"
+REPO_NAME = "Apptopia"
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+HEADERS = {
+    "Accept": "application/vnd.github.v3+json",
+    "User-Agent": "Triage-Agent"
+}
+if GITHUB_TOKEN:
+    HEADERS["Authorization"] = f"token {GITHUB_TOKEN}"
+
+API_BASE = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
+MY_USERNAME = "doggy8088"  # Assuming I am the owner/maintainer
+
+# Required sections from README.md
+REQUIRED_SECTIONS = [
+    "基本資訊",
+    "需求定義",
+    "驗收標準"
+]
+
+def log(msg):
+    print(f"[Triage] {msg}")
+
+def make_request(url, method="GET", data=None):
+    req = urllib.request.Request(url, headers=HEADERS, method=method)
+    if data:
+        req.data = json.dumps(data).encode("utf-8")
+        req.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        log(f"HTTP Error {e.code}: {e.reason} for {url}")
+        if e.code == 403:
+             log("Rate limit likely exceeded or permission denied.")
+        return None
+    except Exception as e:
+        log(f"Error: {e}")
+        return None
+
+def get_open_issues():
+    issues = []
+    page = 1
+    while True:
+        url = f"{API_BASE}/issues?state=open&per_page=100&page={page}"
+        data = make_request(url)
+        if not data:
+            break
+        # Filter out PRs, as the endpoint returns both issues and PRs
+        page_issues = [i for i in data if "pull_request" not in i]
+        if page_issues:
+            issues.extend(page_issues)
+        page += 1
+    return issues
+
+def get_issue_comments(issue_number):
+    url = f"{API_BASE}/issues/{issue_number}/comments"
+    return make_request(url) or []
+
+def analyze_issue(issue, dry_run=True):
+    number = issue["number"]
+    title = issue["title"]
+    body = issue["body"] or ""
+    author = issue["user"]["login"]
+
+    log(f"Analyzing Issue #{number}: {title}")
+
+    comments = get_issue_comments(number)
+
+    # 1. Check if the last comment is mine or bot's
+    if comments:
+        last_comment = comments[-1]
+        last_commenter = last_comment["user"]["login"]
+        if last_commenter == MY_USERNAME or "bot" in last_commenter.lower() or "github-actions" in last_commenter:
+            log(f"  -> Skipping: Last comment is by {last_commenter}.")
+            return
+    else:
+        # No comments yet, check if creator is me (unlikely for triage but good to handle)
+        if author == MY_USERNAME:
+            log(f"  -> Skipping: Issue created by me ({MY_USERNAME}).")
+            return
+
+    # 2. Analyze requirements
+    missing_sections = []
+    for section in REQUIRED_SECTIONS:
+        if section not in body:
+            missing_sections.append(section)
+
+    is_clear = len(missing_sections) == 0
+
+    if is_clear:
+        log(f"  -> Requirements look clear. Preparing plan...")
+        post_plan(issue, dry_run)
+    else:
+        log(f"  -> Requirements unclear. Missing: {', '.join(missing_sections)}")
+        request_info(issue, missing_sections, dry_run)
+
+def request_info(issue, missing_sections, dry_run=True):
+    number = issue["number"]
+    author = issue["user"]["login"]
+
+    msg = (f"Hi @{author}, 感謝你的提案！\n\n"
+           f"為了讓這個需求能更順利被實作，能否請你補充以下資訊？\n"
+           f"- " + "\n- ".join(missing_sections) + "\n\n"
+           f"參考 [README](https://github.com/{REPO_OWNER}/{REPO_NAME}/blob/main/README.md#%E9%9C%80%E6%B1%82%E6%92%B0%E5%AF%AB%E8%A6%8F%E6%A0%BCissue-%E5%BF%85%E5%A1%AB) 的格式會非常有幫助。謝謝！")
+
+    if dry_run:
+        print(f"DEBUG: Would post comment on #{number}:\n---\n{msg}\n---")
+    else:
+        log(f"  -> Posting comment to request info on #{number}...")
+        post_comment(number, msg)
+
+def post_plan(issue, dry_run=True):
+    number = issue["number"]
+
+    plan = (f"## 開發計畫 (Draft)\n\n"
+            f"根據需求，預計執行以下步驟：\n\n"
+            f"### Scope\n"
+            f"- [ ] TBD\n\n"
+            f"### Acceptance criteria (verifiable)\n"
+            f"- [ ] TBD\n\n"
+            f"### Verification\n"
+            f"- [ ] TBD\n\n"
+            f"### Risks\n"
+            f"- TBD\n\n"
+            f"### Rollback notes\n"
+            f"- TBD\n")
+
+    if dry_run:
+        print(f"DEBUG: Would post plan on #{number}:\n---\n{plan}\n---")
+    else:
+        log(f"  -> Posting plan on #{number}...")
+        post_comment(number, plan)
+
+def post_comment(issue_number, body):
+    url = f"{API_BASE}/issues/{issue_number}/comments"
+    make_request(url, method="POST", data={"body": body})
+
+def main():
+    parser = argparse.ArgumentParser(description="Triage GitHub issues.")
+    parser.add_argument("--run", action="store_true", help="Actually post comments to GitHub.")
+    parser.add_argument("--dry-run", action="store_true", default=True, help="Print actions without posting (default).")
+    args = parser.parse_args()
+
+    # If --run is specified, dry_run is False. Otherwise it's True.
+    # Note: The argparse default for store_true is False.
+    # If user runs without args: --run is False, --dry-run is True (default).
+    # If user runs --run: --run is True.
+    # We want dry_run to be True unless --run is specified.
+
+    dry_run = not args.run
+
+    log(f"Starting triage check (Dry Run: {dry_run})...")
+    issues = get_open_issues()
+    if issues is None:
+        log("Failed to fetch issues. Exiting.")
+        return
+
+    log(f"Found {len(issues)} open issues.")
+
+    for issue in issues:
+        analyze_issue(issue, dry_run)
+        # Sleep to avoid rate limits
+        time.sleep(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces an automated triage script (`scripts/triage_check.py`) and its test suite. The script scans open GitHub issues, filtering out those where the maintainer or a bot was the last commenter. It then analyzes the issue body for required sections defined in `README.md` ("基本資訊", "需求定義", "驗收標準"). Issues missing these sections trigger a simulated "Request for Info" comment, while complete issues trigger a simulated "Development Plan" comment. The script defaults to a dry-run mode.

---
*PR created automatically by Jules for task [15084524183284798421](https://jules.google.com/task/15084524183284798421) started by @doggy8088*